### PR TITLE
CI build will now run flake8 before running tox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
   - poetry install -v
   - pip install tox-travis
   - pip install flake8
-before-script:
-  - flake8
 script:
+  - flake8
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ install:
   - pip install tox-travis
   - pip install flake8
 script:
-  - flake8
   - tox
+  - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ before_install:
 install:
   - poetry install -v
   - pip install tox-travis
+  - pip install flake8
+before-script:
+  - flake8
 script:
   - tox


### PR DESCRIPTION
Pretty simple, for each CI build, flake8 will now run before tox tests, linting all the python files in our project.