### PR TITLE
Add superficial loss

### DIFF
--- a/capgains/commands/capgains_calc.py
+++ b/capgains/commands/capgains_calc.py
@@ -54,6 +54,9 @@ def _filter_calculated_transaction(transaction, year):
     # 'SELL' transactions are the only ones that contribute to gain/loss
     if transaction.action != 'SELL':
         return False
+    # Only non superficial loss transactions
+    if transaction.superficial_loss:
+        return False
     return True
 
 

--- a/capgains/commands/capgains_calc.py
+++ b/capgains/commands/capgains_calc.py
@@ -65,9 +65,7 @@ def get_calculated_dicts(transactions, year, ticker):
         return None
     er = ExchangeRate('USD', transactions[0].date, transactions[-1].date)
     tg = TickerGains(ticker)
-    for transaction in filtered_transactions:
-        rate = er.get_rate(transaction.date)
-        tg.add_transaction(transaction, rate)
+    tg.add_transactions(filtered_transactions, er)
     year_transactions = list(filter(
         lambda t: _filter_calculated_transaction(t, year),
         filtered_transactions))

--- a/capgains/ticker_gains.py
+++ b/capgains/ticker_gains.py
@@ -11,7 +11,37 @@ class TickerGains:
     def ticker(self, ticker):
         return self._ticker
 
-    def add_transaction(self, transaction, exchange_rate):
+    def add_transactions(self, transactions, exchange_rate):
+        """Adds all transactions and updates the calculated values"""
+        for transaction in transactions:
+            rate = exchange_rate.get_rate(transaction.date)
+            self._add_transaction(transaction, rate)
+            if (self._is_superficial_loss(transaction, transactions)):
+                print("It is a superficial loss")
+
+
+    def _superficial_window_filter(transaction, min_date, max_date):
+        return transaction.action == 'BUY' and \
+               transaction.date >= min_date and \
+               transaction.date <= max_date
+
+
+    def _is_superficial_loss(self, transaction, transactions):
+        """Figures out if the transaction is a superficial loss"""
+        if (transaction.capital_gain >= 0):
+            return False
+
+        # Filter out BUY transactions that fall within the 61 day superficial loss window
+        min_date = transaction.date - timedelta(days=30)
+        max_date = transaction.date + timedelta(days=30)
+        filtered_transactions = list(filter(
+        lambda t: self._superficial_window_filter(t, min_date=min_date, max_date=max_date),
+        transactions))
+
+        return len(filtered_transactions) > 0
+
+
+    def _add_transaction(self, transaction, exchange_rate):
         """Adds a transaction and updates the calculated values."""
         new_share_balance = self._share_balance
         new_total_acb = self._total_acb
@@ -31,7 +61,7 @@ class TickerGains:
             capital_gain = 0.0
             acb_delta = -proceeds
         new_total_acb += acb_delta
-        if self._share_balance < 0:
+        if new_share_balance < 0:
             raise ClickException("Transaction caused negative share balance")
         transaction.share_balance = new_share_balance
         transaction.proceeds = proceeds

--- a/capgains/transaction.py
+++ b/capgains/transaction.py
@@ -28,6 +28,7 @@ class Transaction:
         self._capital_gain = None
         self._acb_delta = None
         self._acb = None
+        self._superficial_loss = None
 
     @property
     def date(self):
@@ -98,6 +99,14 @@ class Transaction:
     @acb.setter
     def acb(self, acb):
         self._acb = acb
+
+    @property
+    def superficial_loss(self):
+        return self._superficial_loss
+
+    @superficial_loss.setter
+    def superficial_loss(self, superficial_loss):
+        self._superficial_loss = superficial_loss
 
     def to_dict(self, calculated_values=False):
         d = OrderedDict()

--- a/tests/test_capgains_calc.py
+++ b/tests/test_capgains_calc.py
@@ -1,4 +1,7 @@
+from datetime import date
+
 import capgains.commands.capgains_calc as CapGainsCalc
+from capgains.transaction import Transaction
 
 
 def test_no_ticker(transactions, capfd, exchange_rates_mock):
@@ -31,7 +34,7 @@ date        transaction_type    ticker    action      qty    price    commission
 
 
 def test_no_transactions(capfd):
-    """Testing capgains_show without any transactions"""
+    """Testing capgains_calc without any transactions"""
     CapGainsCalc.capgains_calc([], 2018)
     out, _ = capfd.readouterr()
     assert out == """\
@@ -40,7 +43,7 @@ No transactions available
 
 
 def test_unknown_year(transactions, capfd, exchange_rates_mock):
-    """Testing capgains_show with a year matching no transactions"""
+    """Testing capgains_calc with a year matching no transactions"""
     CapGainsCalc.capgains_calc(transactions, 1998)
     out, _ = capfd.readouterr()
     assert out == """\
@@ -51,3 +54,45 @@ GOOGL-1998
 No capital gains
 
 """
+
+
+def test_superficial_loss_not_displayed(capfd, exchange_rates_mock):
+    """Testing capgains_calc with a superficial loss transaction"""
+    transactions = [
+        Transaction(
+            date(2018, 1, 1),
+            'ESPP PURCHASE',
+            'ANET',
+            'BUY',
+            100,
+            100.00,
+            10.00,
+        ),
+        Transaction(
+            date(2018, 1, 2),
+            'RSU VEST',
+            'ANET',
+            'SELL',
+            99,
+            50.00,
+            10.00,
+        ),
+        Transaction(
+            date(2018, 12, 1),
+            'RSU VEST',
+            'ANET',
+            'SELL',
+            1,
+            1000.00,
+            10.00,
+        )
+    ]
+    CapGainsCalc.capgains_calc(transactions, 2018)
+    out, _ = capfd.readouterr()
+    assert out == """\
+ANET-2018
+date        transaction_type    ticker    action      qty     price    commission    share_balance    proceeds    capital_gain    acb_delta    acb
+----------  ------------------  --------  --------  -----  --------  ------------  ---------------  ----------  --------------  -----------  -----
+2018-12-01  RSU VEST            ANET      SELL          1  1,000.00         10.00                0    1,980.00        1,779.80      -200.20   0.00
+
+"""  # noqa: E501

--- a/tests/test_ticker_gains.py
+++ b/tests/test_ticker_gains.py
@@ -1,4 +1,6 @@
 from capgains.ticker_gains import TickerGains
+from capgains.exchange_rate import ExchangeRate
+from click import ClickException
 import pytest
 
 
@@ -7,31 +9,35 @@ def test_ticker_gains_negative_balance(transactions):
     this causes a negative balance, which is impossible"""
     sell_transaction = transactions[2]
     tg = TickerGains(sell_transaction.ticker)
-    with pytest.raises(ValueError):
-        tg.add_transaction(sell_transaction, 1.2622)
+    er = ExchangeRate('USD', transactions[2].date, transactions[2].date)
+    with pytest.raises(ClickException):
+        tg.add_transactions([sell_transaction], er)
 
 
 def test_ticker_gains_ok(transactions):
     tg = TickerGains(transactions[0].ticker)
+    er = ExchangeRate('USD', transactions[0].date, transactions[3].date)
 
     # Add first transaction - 'BUY'
-    tg.add_transaction(transactions[0], 2.0)
+    # Add second transaction - 'BUY'
+    # Add third transaction - 'SELL'
+    transactions_to_test = [transactions[0],
+                            transactions[2],
+                            transactions[3]]
+    
+    tg.add_transactions(transactions_to_test, er)
     assert transactions[0].share_balance == 100
     assert transactions[0].proceeds == -10020.00
     assert transactions[0].capital_gain == 0.0
     assert transactions[0].acb_delta == 10020.00
     assert transactions[0].acb == 10020.00
 
-    # Add second transaction - 'BUY'
-    tg.add_transaction(transactions[2], 2.0)
     assert transactions[2].share_balance == 50
     assert transactions[2].proceeds == 11980.00
     assert transactions[2].capital_gain == 6970.00
     assert transactions[2].acb_delta == -5010.00
     assert transactions[2].acb == 5010.00
 
-    # Add third transaction - 'SELL'
-    tg.add_transaction(transactions[3], 2.0)
     assert transactions[3].share_balance == 100
     assert transactions[3].proceeds == -13020.00
     assert transactions[3].capital_gain == 0.0

--- a/tests/test_ticker_gains.py
+++ b/tests/test_ticker_gains.py
@@ -40,7 +40,7 @@ def test_superficial_loss_no_purchase_after_loss(exchange_rates_mock):
 
 def test_superficial_loss_purchase_after_loss(exchange_rates_mock):
     """Testing if transaction is marked as a superficial loss even if
-    there are is a purchase made after the loss"""
+    there is a purchase made after the loss"""
     transactions = [
         Transaction(
             date(2018, 1, 1),


### PR DESCRIPTION
### Adding support for superficial loss calculation

**Changes in ticker_gains.py:**

Using these conditions to determine if a transaction resulted in a superficial loss:

(All 3 conditions must be true)
1) Capital gain must be negative
2) The must be a 'BUY' transaction that occurred in the period starting 30 days prior to the loss and ending 30 days after the loss
3) There must be a positive share balance after the last transaction in the period ending 30 days after the loss occurs

**Changes in capgains_calc:**

Only display the transactions which did not result in a superficial loss