### PR TITLE
Adding a currency column to the expected input transactions

### DIFF
--- a/capgains/commands/capgains_calc.py
+++ b/capgains/commands/capgains_calc.py
@@ -71,9 +71,11 @@ def _get_map_of_currencies_to_exchange_rates(transactions):
         if currency not in currency_date_ranges:
             currency_date_ranges[currency] = (date, date)
         elif date < currency_date_ranges[currency][0]:
+            # Set the minimum date
             currency_date_ranges[currency] = \
                 (date, currency_date_ranges[currency][1])
         elif date > currency_date_ranges[currency][1]:
+            # Set the maximum date
             currency_date_ranges[currency] = \
                 (currency_date_ranges[currency][0], date)
     currencies_to_exchange_rates = dict()

--- a/capgains/commands/capgains_calc.py
+++ b/capgains/commands/capgains_calc.py
@@ -12,6 +12,7 @@ colalign = (
     "right",  # qty
     "right",  # price
     "right",  # commission
+    "right",  # currency
     "right",  # share_balance
     "right",  # proceeds
     "right",  # capital_gain
@@ -27,6 +28,7 @@ floatfmt = (
     None,    # qty
     ",.2f",  # price
     ",.2f",  # commission
+    None,    # currency
     None,    # share_balance
     ",.2f",  # proceeds
     ",.2f",  # capital_gain
@@ -60,15 +62,39 @@ def _filter_calculated_transaction(transaction, year):
     return True
 
 
+def _get_map_of_currencies_to_exchange_rates(transactions):
+    currency_date_ranges = dict()
+    # First, map the currency to a range of dates it needs
+    for transaction in transactions:
+        currency = transaction.currency
+        date = transaction.date
+        if currency not in currency_date_ranges:
+            currency_date_ranges[currency] = (date, date)
+        elif date < currency_date_ranges[currency][0]:
+            currency_date_ranges[currency] = \
+                (date, currency_date_ranges[currency][1])
+        elif date > currency_date_ranges[currency][1]:
+            currency_date_ranges[currency] = \
+                (currency_date_ranges[currency][0], date)
+    currencies_to_exchange_rates = dict()
+    # Next, map the currency to an ExchangeRate object
+    for currency in currency_date_ranges.keys():
+        first_date = currency_date_ranges[currency][0]
+        last_date = currency_date_ranges[currency][1]
+        currencies_to_exchange_rates[currency] = \
+            ExchangeRate(currency, first_date, last_date)
+    return currencies_to_exchange_rates
+
+
 def get_calculated_dicts(transactions, year, ticker):
     filtered_transactions = list(filter(
         lambda t: _filter_transaction(t, max_year=year, ticker=ticker),
         transactions))
     if not filtered_transactions:
         return None
-    er = ExchangeRate('USD', transactions[0].date, transactions[-1].date)
+    er_map = _get_map_of_currencies_to_exchange_rates(transactions)
     tg = TickerGains(ticker)
-    tg.add_transactions(filtered_transactions, er)
+    tg.add_transactions(filtered_transactions, er_map)
     year_transactions = list(filter(
         lambda t: _filter_calculated_transaction(t, year),
         filtered_transactions))

--- a/capgains/commands/capgains_show.py
+++ b/capgains/commands/capgains_show.py
@@ -11,6 +11,7 @@ colalign = (
     "right",  # qty
     "right",  # price
     "right",  # commission
+    "right",  # currency
 )
 
 floatfmt = (
@@ -21,6 +22,7 @@ floatfmt = (
     None,    # qty
     ",.2f",  # price
     ",.2f",  # commission
+    None,    # currency
 )
 
 

--- a/capgains/exchange_rate.py
+++ b/capgains/exchange_rate.py
@@ -10,6 +10,7 @@ class ExchangeRate:
     currency_to = 'CAD'
     date = 'd'
     value = 'v'
+    supported_currencies = ['CAD', 'USD']
 
     def _init_cad_to_cad(self, start_date, end_date):
         """The API doesn't support CAD -> CAD, so just set the rates to 1
@@ -65,6 +66,11 @@ class ExchangeRate:
         self._start_date = start_date
         self._end_date = end_date
         self._rates = dict()
+
+        if currency_from not in self.supported_currencies:
+            raise ClickException(
+                "Currency ({}) is not currently supported. The supported currencies are {}"  # noqa: E501
+                .format(currency_from, self.supported_currencies))
 
         if end_date < start_date:
             raise ClickException(

--- a/capgains/exchange_rate.py
+++ b/capgains/exchange_rate.py
@@ -12,8 +12,9 @@ class ExchangeRate:
     value = 'v'
 
     def _init_cad_to_cad(self, start_date, end_date):
-        # The API doesn't support CAD -> CAD, so just set the rate to 1
-        num_days = (end_date - start_date).days
+        """The API doesn't support CAD -> CAD, so just set the rates to 1
+        for all days"""
+        num_days = (end_date - start_date).days + 1
         for date in \
                 (start_date + timedelta(days=n) for n in range(num_days)):
             self._rates[date] = 1

--- a/capgains/ticker_gains.py
+++ b/capgains/ticker_gains.py
@@ -12,10 +12,10 @@ class TickerGains:
     def ticker(self, ticker):
         return self._ticker
 
-    def add_transactions(self, transactions, exchange_rate_map):
+    def add_transactions(self, transactions, exchange_rates):
         """Adds all transactions and updates the calculated values"""
         for transaction in transactions:
-            rate = exchange_rate_map[transaction.currency] \
+            rate = exchange_rates[transaction.currency] \
                     .get_rate(transaction.date)
             self._add_transaction(transaction, rate)
             transaction.superficial_loss = \

--- a/capgains/ticker_gains.py
+++ b/capgains/ticker_gains.py
@@ -12,10 +12,11 @@ class TickerGains:
     def ticker(self, ticker):
         return self._ticker
 
-    def add_transactions(self, transactions, exchange_rate):
+    def add_transactions(self, transactions, exchange_rate_map):
         """Adds all transactions and updates the calculated values"""
         for transaction in transactions:
-            rate = exchange_rate.get_rate(transaction.date)
+            rate = exchange_rate_map[transaction.currency] \
+                    .get_rate(transaction.date)
             self._add_transaction(transaction, rate)
             transaction.superficial_loss = \
                 self._is_superficial_loss(transaction, transactions)

--- a/capgains/transaction.py
+++ b/capgains/transaction.py
@@ -10,12 +10,13 @@ class Transaction:
     qty_idx = 4
     price_idx = 5
     commission_idx = 6
-    num_vals_show = 7
+    currency_idx = 7
+    num_vals_show = 8
     num_vals_calculated = 5
     num_vals_all = num_vals_show + num_vals_calculated
 
     def __init__(self, date, transaction_type, ticker, action, qty, price,
-                 commission):
+                 commission, currency):
         self._date = date
         self._transaction_type = transaction_type
         self._ticker = ticker
@@ -23,6 +24,7 @@ class Transaction:
         self._qty = qty
         self._price = price
         self._commission = commission
+        self._currency = currency
         self._share_balance = None
         self._proceeds = None
         self._capital_gain = None
@@ -57,6 +59,10 @@ class Transaction:
     @property
     def commission(self):
         return self._commission
+
+    @property
+    def currency(self):
+        return self._currency
 
     @property
     def share_balance(self):
@@ -117,6 +123,7 @@ class Transaction:
         d['qty'] = self.qty
         d['price'] = self.price
         d['commission'] = self.commission
+        d['currency'] = self.currency
         if calculated_values:
             d['share_balance'] = self.share_balance
             d['proceeds'] = self.proceeds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def transactions():
             100,
             50.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 2, 20),
@@ -30,6 +31,7 @@ def transactions():
             30,
             20.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 2, 20),
@@ -39,6 +41,7 @@ def transactions():
             50,
             120.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2019, 2, 15),
@@ -48,6 +51,7 @@ def transactions():
             50,
             130.00,
             10.00,
+            'USD'
         )
     ]
     return trans

--- a/tests/test_capgains.py
+++ b/tests/test_capgains.py
@@ -34,12 +34,12 @@ def test_show_no_ticker_arg(testfiles_dir, transactions):
 
     assert result.exit_code == 0
     assert result.output == """\
-date        transaction_type    ticker    action      qty    price    commission
-----------  ------------------  --------  --------  -----  -------  ------------
-2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00
-2018-02-20  RSU VEST            GOOGL     BUY          30    20.00         10.00
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00
-2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00
+date        transaction_type    ticker    action      qty    price    commission    currency
+----------  ------------------  --------  --------  -----  -------  ------------  ----------
+2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00         USD
+2018-02-20  RSU VEST            GOOGL     BUY          30    20.00         10.00         USD
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD
+2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00         USD
 """  # noqa: E501
 
 
@@ -55,11 +55,11 @@ def test_show_ticker_arg(testfiles_dir, transactions):
 
     assert result.exit_code == 0
     assert result.output == """\
-date        transaction_type    ticker    action      qty    price    commission
-----------  ------------------  --------  --------  -----  -------  ------------
-2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00
-2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00
+date        transaction_type    ticker    action      qty    price    commission    currency
+----------  ------------------  --------  --------  -----  -------  ------------  ----------
+2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00         USD
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD
+2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00         USD
 """  # noqa: E501
 
 
@@ -76,9 +76,9 @@ def test_calc_no_ticker_arg(testfiles_dir, transactions, exchange_rates_mock):
     assert result.exit_code == 0
     assert result.output == """\
 ANET-2018
-date        transaction_type    ticker    action      qty    price    commission    share_balance    proceeds    capital_gain    acb_delta       acb
-----------  ------------------  --------  --------  -----  -------  ------------  ---------------  ----------  --------------  -----------  --------
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00               50   11,980.00        6,970.00    -5,010.00  5,010.00
+date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta       acb
+----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  --------
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD               50   11,980.00        6,970.00    -5,010.00  5,010.00
 
 GOOGL-2018
 No capital gains
@@ -99,9 +99,9 @@ def test_calc_ticker_arg(testfiles_dir, transactions, exchange_rates_mock):
     assert result.exit_code == 0
     assert result.output == """\
 ANET-2018
-date        transaction_type    ticker    action      qty    price    commission    share_balance    proceeds    capital_gain    acb_delta       acb
-----------  ------------------  --------  --------  -----  -------  ------------  ---------------  ----------  --------------  -----------  --------
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00               50   11,980.00        6,970.00    -5,010.00  5,010.00
+date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta       acb
+----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  --------
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD               50   11,980.00        6,970.00    -5,010.00  5,010.00
 
 """  # noqa: E501
 

--- a/tests/test_capgains_calc.py
+++ b/tests/test_capgains_calc.py
@@ -10,9 +10,9 @@ def test_no_ticker(transactions, capfd, exchange_rates_mock):
     out, _ = capfd.readouterr()
     assert out == """\
 ANET-2018
-date        transaction_type    ticker    action      qty    price    commission    share_balance    proceeds    capital_gain    acb_delta       acb
-----------  ------------------  --------  --------  -----  -------  ------------  ---------------  ----------  --------------  -----------  --------
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00               50   11,980.00        6,970.00    -5,010.00  5,010.00
+date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta       acb
+----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  --------
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD               50   11,980.00        6,970.00    -5,010.00  5,010.00
 
 GOOGL-2018
 No capital gains
@@ -26,9 +26,9 @@ def test_tickers(transactions, capfd, exchange_rates_mock):
     out, _ = capfd.readouterr()
     assert out == """\
 ANET-2018
-date        transaction_type    ticker    action      qty    price    commission    share_balance    proceeds    capital_gain    acb_delta       acb
-----------  ------------------  --------  --------  -----  -------  ------------  ---------------  ----------  --------------  -----------  --------
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00               50   11,980.00        6,970.00    -5,010.00  5,010.00
+date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta       acb
+----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  --------
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD               50   11,980.00        6,970.00    -5,010.00  5,010.00
 
 """  # noqa: E501
 
@@ -67,6 +67,7 @@ def test_superficial_loss_not_displayed(capfd, exchange_rates_mock):
             100,
             100.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 1, 2),
@@ -76,6 +77,7 @@ def test_superficial_loss_not_displayed(capfd, exchange_rates_mock):
             99,
             50.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 12, 1),
@@ -85,14 +87,15 @@ def test_superficial_loss_not_displayed(capfd, exchange_rates_mock):
             1,
             1000.00,
             10.00,
+            'USD'
         )
     ]
     CapGainsCalc.capgains_calc(transactions, 2018)
     out, _ = capfd.readouterr()
     assert out == """\
 ANET-2018
-date        transaction_type    ticker    action      qty     price    commission    share_balance    proceeds    capital_gain    acb_delta    acb
-----------  ------------------  --------  --------  -----  --------  ------------  ---------------  ----------  --------------  -----------  -----
-2018-12-01  RSU VEST            ANET      SELL          1  1,000.00         10.00                0    1,980.00        1,779.80      -200.20   0.00
+date        transaction_type    ticker    action      qty     price    commission    currency    share_balance    proceeds    capital_gain    acb_delta    acb
+----------  ------------------  --------  --------  -----  --------  ------------  ----------  ---------------  ----------  --------------  -----------  -----
+2018-12-01  RSU VEST            ANET      SELL          1  1,000.00         10.00         USD                0    1,980.00        1,779.80      -200.20   0.00
 
 """  # noqa: E501

--- a/tests/test_capgains_show.py
+++ b/tests/test_capgains_show.py
@@ -6,12 +6,12 @@ def test_no_filter(transactions, capfd):
     CapGainsShow.capgains_show(transactions)
     out, _ = capfd.readouterr()
     assert out == """\
-date        transaction_type    ticker    action      qty    price    commission
-----------  ------------------  --------  --------  -----  -------  ------------
-2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00
-2018-02-20  RSU VEST            GOOGL     BUY          30    20.00         10.00
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00
-2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00
+date        transaction_type    ticker    action      qty    price    commission    currency
+----------  ------------------  --------  --------  -----  -------  ------------  ----------
+2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00         USD
+2018-02-20  RSU VEST            GOOGL     BUY          30    20.00         10.00         USD
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD
+2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00         USD
 """  # noqa: E501
 
 
@@ -29,11 +29,11 @@ def test_ticker(transactions, capfd):
     CapGainsShow.capgains_show(transactions, tickers=['ANET'])
     out, _ = capfd.readouterr()
     assert out == """\
-date        transaction_type    ticker    action      qty    price    commission
-----------  ------------------  --------  --------  -----  -------  ------------
-2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00
-2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00
+date        transaction_type    ticker    action      qty    price    commission    currency
+----------  ------------------  --------  --------  -----  -------  ------------  ----------
+2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00         USD
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD
+2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00         USD
 """  # noqa: E501
 
 
@@ -55,9 +55,9 @@ def test_known_ticker_and_unknown_ticker(transactions, capfd):
     CapGainsShow.capgains_show(transactions, ['GOOGL', 'FB'])
     out, _ = capfd.readouterr()
     assert out == """\
-date        transaction_type    ticker    action      qty    price    commission
-----------  ------------------  --------  --------  -----  -------  ------------
-2018-02-20  RSU VEST            GOOGL     BUY          30    20.00         10.00
+date        transaction_type    ticker    action      qty    price    commission    currency
+----------  ------------------  --------  --------  -----  -------  ------------  ----------
+2018-02-20  RSU VEST            GOOGL     BUY          30    20.00         10.00         USD
 """  # noqa: E501
 
 
@@ -68,10 +68,10 @@ def test_multiple_tickers(transactions, capfd):
     CapGainsShow.capgains_show(transactions, ['ANET', 'GOOGL'])
     out, _ = capfd.readouterr()
     assert out == """\
-date        transaction_type    ticker    action      qty    price    commission
-----------  ------------------  --------  --------  -----  -------  ------------
-2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00
-2018-02-20  RSU VEST            GOOGL     BUY          30    20.00         10.00
-2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00
-2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00
+date        transaction_type    ticker    action      qty    price    commission    currency
+----------  ------------------  --------  --------  -----  -------  ------------  ----------
+2017-02-15  ESPP PURCHASE       ANET      BUY         100    50.00         10.00         USD
+2018-02-20  RSU VEST            GOOGL     BUY          30    20.00         10.00         USD
+2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD
+2019-02-15  ESPP PURCHASE       ANET      BUY          50   130.00         10.00         USD
 """  # noqa: E501

--- a/tests/test_exchange_rate.py
+++ b/tests/test_exchange_rate.py
@@ -76,3 +76,9 @@ def test_exchange_rate_weekend_date(USD_exchange_rates_mock):
     er = ExchangeRate('USD', ExchangeRate.min_date, date.today())
     expected_rate = er.get_rate(friday)
     assert er.get_rate(sunday) == expected_rate
+
+
+def test_cad_to_cad_rate_is_1():
+    day = date(2020, 5, 22)
+    er = ExchangeRate('CAD', day, day)
+    assert er.get_rate(day) == 1

--- a/tests/test_exchange_rate.py
+++ b/tests/test_exchange_rate.py
@@ -82,3 +82,9 @@ def test_cad_to_cad_rate_is_1():
     day = date(2020, 5, 22)
     er = ExchangeRate('CAD', day, day)
     assert er.get_rate(day) == 1
+
+
+def test_unsupported_currency_returns_error():
+    with pytest.raises(ClickException):
+        day = date(2020, 5, 22)
+        ExchangeRate("BLAHBLAH", day, day)

--- a/tests/test_ticker_gains.py
+++ b/tests/test_ticker_gains.py
@@ -19,6 +19,7 @@ def test_superficial_loss_no_purchase_after_loss(exchange_rates_mock):
             100,
             100.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 1, 2),
@@ -28,12 +29,14 @@ def test_superficial_loss_no_purchase_after_loss(exchange_rates_mock):
             99,
             50.00,
             10.00,
+            'USD'
         )
     ]
     tg = TickerGains(transactions[0].ticker)
     er = ExchangeRate('USD', transactions[0].date,
                       transactions[1].date)
-    tg.add_transactions(transactions, er)
+    er_map = {'USD': er}
+    tg.add_transactions(transactions, er_map)
     assert transactions[1].superficial_loss
     assert transactions[1].capital_gain == 0
 
@@ -50,6 +53,7 @@ def test_superficial_loss_purchase_after_loss(exchange_rates_mock):
             100,
             100.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 1, 2),
@@ -59,6 +63,7 @@ def test_superficial_loss_purchase_after_loss(exchange_rates_mock):
             99,
             50.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 1, 3),
@@ -68,12 +73,14 @@ def test_superficial_loss_purchase_after_loss(exchange_rates_mock):
             1,
             100.00,
             10.00,
+            'USD'
         )
     ]
     tg = TickerGains(transactions[0].ticker)
     er = ExchangeRate('USD', transactions[0].date,
                       transactions[1].date)
-    tg.add_transactions(transactions, er)
+    er_map = {'USD': er}
+    tg.add_transactions(transactions, er_map)
     assert transactions[1].superficial_loss
     assert transactions[1].capital_gain == 0
 
@@ -90,6 +97,7 @@ def test_loss_no_balance_after_window(exchange_rates_mock):
             100,
             100.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 1, 2),
@@ -99,6 +107,7 @@ def test_loss_no_balance_after_window(exchange_rates_mock):
             99,
             50.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 1, 3),
@@ -108,6 +117,7 @@ def test_loss_no_balance_after_window(exchange_rates_mock):
             1,
             100.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 2, 10),
@@ -117,12 +127,14 @@ def test_loss_no_balance_after_window(exchange_rates_mock):
             1,
             100.00,
             10.00,
+            'USD'
         )
     ]
     tg = TickerGains(transactions[0].ticker)
     er = ExchangeRate('USD', transactions[0].date,
                       transactions[1].date)
-    tg.add_transactions(transactions, er)
+    er_map = {'USD': er}
+    tg.add_transactions(transactions, er_map)
     assert not transactions[1].superficial_loss
     assert transactions[1].capital_gain < 0
 
@@ -139,6 +151,7 @@ def test_loss_no_purchase_in_window(exchange_rates_mock):
             100,
             100.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 8, 1),
@@ -148,6 +161,7 @@ def test_loss_no_purchase_in_window(exchange_rates_mock):
             99,
             50.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 12, 1),
@@ -157,12 +171,14 @@ def test_loss_no_purchase_in_window(exchange_rates_mock):
             1,
             50.00,
             10.00,
+            'USD'
         )
     ]
     tg = TickerGains(transactions[0].ticker)
     er = ExchangeRate('USD', transactions[0].date,
                       transactions[1].date)
-    tg.add_transactions(transactions, er)
+    er_map = {'USD': er}
+    tg.add_transactions(transactions, er_map)
     assert not transactions[1].superficial_loss
     assert transactions[1].capital_gain < 0
 
@@ -179,6 +195,7 @@ def test_gain_not_marked_as_superficial_loss(exchange_rates_mock):
             100,
             1.00,
             10.00,
+            'USD'
         ),
         Transaction(
             date(2018, 8, 1),
@@ -188,12 +205,14 @@ def test_gain_not_marked_as_superficial_loss(exchange_rates_mock):
             100,
             50.00,
             10.00,
+            'USD'
         )
     ]
     tg = TickerGains(transactions[0].ticker)
     er = ExchangeRate('USD', transactions[0].date,
                       transactions[1].date)
-    tg.add_transactions(transactions, er)
+    er_map = {'USD': er}
+    tg.add_transactions(transactions, er_map)
     assert not transactions[1].superficial_loss
     assert transactions[1].capital_gain > 0
 
@@ -204,13 +223,15 @@ def test_ticker_gains_negative_balance(transactions, exchange_rates_mock):
     sell_transaction = transactions[2]
     tg = TickerGains(sell_transaction.ticker)
     er = ExchangeRate('USD', transactions[2].date, transactions[2].date)
+    er_map = {'USD': er}
     with pytest.raises(ClickException):
-        tg.add_transactions([sell_transaction], er)
+        tg.add_transactions([sell_transaction], er_map)
 
 
 def test_ticker_gains_ok(transactions, exchange_rates_mock):
     tg = TickerGains(transactions[0].ticker)
     er = ExchangeRate('USD', transactions[0].date, transactions[3].date)
+    er_map = {'USD': er}
 
     # Add first transaction - 'BUY'
     # Add second transaction - 'BUY'
@@ -219,7 +240,7 @@ def test_ticker_gains_ok(transactions, exchange_rates_mock):
                             transactions[2],
                             transactions[3]]
 
-    tg.add_transactions(transactions_to_test, er)
+    tg.add_transactions(transactions_to_test, er_map)
     assert transactions[0].share_balance == 100
     assert transactions[0].proceeds == -10020.00
     assert transactions[0].capital_gain == 0.0

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -12,6 +12,7 @@ def test_transactions_to_dict(transactions):
     assert trans_dict['qty'] == 100
     assert trans_dict['price'] == 50.00
     assert trans_dict['commission'] == 10.00
+    assert trans_dict['currency'] == 'USD'
 
     # check that no extra values were added
     assert len(trans_dict) == Transaction.num_vals_show
@@ -27,6 +28,7 @@ def test_transactions_to_dict_calculated_partially_populated(transactions):
     assert trans_dict['qty'] == 100
     assert trans_dict['price'] == 50.00
     assert trans_dict['commission'] == 10.00
+    assert trans_dict['currency'] == 'USD'
     assert trans_dict['share_balance'] is None
     assert trans_dict['proceeds'] is None
     assert trans_dict['capital_gain'] is None
@@ -53,6 +55,7 @@ def test_transactions_to_dict_calculated_fully_populated(transactions):
     assert trans_dict['qty'] == 100
     assert trans_dict['price'] == 50.00
     assert trans_dict['commission'] == 10.00
+    assert trans_dict['currency'] == 'USD'
     assert trans_dict['share_balance'] == 50
     assert trans_dict['proceeds'] == 5000.00
     assert trans_dict['capital_gain'] == 5010.00

--- a/tests/test_transactions_reader.py
+++ b/tests/test_transactions_reader.py
@@ -14,7 +14,8 @@ def test_transactions_reader_default(testfiles_dir, transactions):
                                   'BUY',
                                   21,
                                   307.96,
-                                  20.99)
+                                  20.99,
+                                  'USD')
     transactions_list = transactions_to_list([exp_transaction])
     filepath = create_csv_file(testfiles_dir,
                                "good.csv",
@@ -35,7 +36,8 @@ def test_transactions_reader_columns_error(testfiles_dir):
                               'BUY',
                               21,
                               307.96,
-                              20.99)
+                              20.99,
+                              'USD')
     transactions_list = transactions_to_list([transaction])
     # Add an extra column to the transaction
     transactions_list[0].append('EXTRA_COLUMN_VALUE')
@@ -70,14 +72,16 @@ def test_transactions_read_wrong_dates_order(testfiles_dir):
                                     'BUY',
                                     42,
                                     249.55,
-                                    0.0)
+                                    0.0,
+                                    'USD')
     transaction_before = Transaction(date(2018, 2, 15),
                                      'ESPP PURCHASE',
                                      'ANET',
                                      'BUY',
                                      21,
                                      307.96,
-                                     20.99)
+                                     20.99,
+                                     'USD')
     transactions_list = transactions_to_list([transaction_after,
                                              transaction_before])
     with pytest.raises(ClickException):


### PR DESCRIPTION
### Fixed #5 

Now, we expect a currency to be added next to every transaction that specifies the currency used in the 'Price' and 'Commission' column.

The calculated values of the calc command will still be displayed in CAD though.

**Breakdown of the changes:**

**1. capgains_calc.py:**
**a.** First map currency to a tuple of (min_date, max_date) where min_date is the earliest date a transaction using this currency occured, and max_date is the latest.

So you might end up with something that looks like:

```
{
    "CAD" : (January 1st 2020, January 2nd 2020),
    "USD" : (January 1st 2020, February 1st 2020)
}
```

**b.** Go over all the currencies detected in step a, create an ExchangeRate object using the min_date and max_date from the tuples created in step b, and map each currency to this new ExchangeRate object.

This gives you something like looks like:

```
{
    "CAD" : (ExchangeRate object with rates from Jan-1-2020 -> Jan-2-2020),
    "USD" : (ExchangeRate object with rates from Jan-1-2020 -> Feb-1-2020) 
}
```

**2. exchange_rate.py:**
**a.** The constructor will check if the currency_from variable is 'CAD', and initialize self._rates to just set every exchange rate to 1 for all the dates. This is because the API cannot do a get request for CAD->CAD, and the rate is just 1 since its the same currency. If the currency is not CAD, then it will proceed to do the original initialization which gets the values from the API call to Bank of Canada.