### PR TITLE
Increase test coverage to 100%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 *.pyc
 
 # Code coverage file
-.coverage
+.coverage*

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Code coverage file
 .coverage*
+
+# Mac
+.DS_Store*

--- a/capgains/ticker_gains.py
+++ b/capgains/ticker_gains.py
@@ -9,7 +9,7 @@ class TickerGains:
         self._total_acb = 0
 
     @property
-    def ticker(self, ticker):
+    def ticker(self):
         return self._ticker
 
     def add_transactions(self, transactions, exchange_rates):

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+    project:
+      default:
+        target: 100%
+
+comment: false

--- a/tests/test_ticker_gains.py
+++ b/tests/test_ticker_gains.py
@@ -258,3 +258,9 @@ def test_ticker_gains_ok(transactions, exchange_rates_mock):
     assert transactions[3].capital_gain == 0.0
     assert transactions[3].acb_delta == 13020.00
     assert transactions[3].acb == 18030.00
+
+
+def test_ticker_gains_properties_set():
+    ticker = 'TEST'
+    tg = TickerGains(ticker)
+    assert tg.ticker == ticker

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,4 +1,6 @@
 from datetime import date
+import pytest
+
 from capgains.transaction import Transaction
 
 
@@ -64,3 +66,8 @@ def test_transactions_to_dict_calculated_fully_populated(transactions):
 
     # check that no extra values were added
     assert len(trans_dict) == Transaction.num_vals_all
+
+
+def test_cannot_set_negative_share_balance(transactions):
+    with pytest.raises(ValueError):
+        transactions[0].share_balance = -1

--- a/tests/test_transactions_reader.py
+++ b/tests/test_transactions_reader.py
@@ -16,10 +16,10 @@ def test_transactions_reader_default(testfiles_dir, transactions):
                                   307.96,
                                   20.99,
                                   'USD')
-    transactions_list = transactions_to_list([exp_transaction])
+    transactions = transactions_to_list([exp_transaction])
     filepath = create_csv_file(testfiles_dir,
                                "good.csv",
-                               transactions_list,
+                               transactions,
                                True)
 
     actual_transactions = TransactionsReader.get_transactions(filepath)
@@ -38,13 +38,13 @@ def test_transactions_reader_columns_error(testfiles_dir):
                               307.96,
                               20.99,
                               'USD')
-    transactions_list = transactions_to_list([transaction])
+    transactions = transactions_to_list([transaction])
     # Add an extra column to the transaction
-    transactions_list[0].append('EXTRA_COLUMN_VALUE')
+    transactions[0].append('EXTRA_COLUMN_VALUE')
     with pytest.raises(ClickException):
         filepath = create_csv_file(testfiles_dir,
                                    "too_many_cols.csv",
-                                   transactions_list,
+                                   transactions,
                                    True)
         TransactionsReader.get_transactions(filepath)
 
@@ -82,11 +82,87 @@ def test_transactions_read_wrong_dates_order(testfiles_dir):
                                      307.96,
                                      20.99,
                                      'USD')
-    transactions_list = transactions_to_list([transaction_after,
-                                             transaction_before])
+    transactions = transactions_to_list([transaction_after,
+                                         transaction_before])
     with pytest.raises(ClickException):
         filepath = create_csv_file(testfiles_dir,
                                    "outoforder.csv,",
-                                   transactions_list,
+                                   transactions,
+                                   True)
+        TransactionsReader.get_transactions(filepath)
+
+
+def test_transactions_date_wrong_format(testfiles_dir):
+    """Testing TransactionsReader with dates entered in wrong format"""
+    transaction = Transaction('January 1st 2020',
+                              'RSU VEST',
+                              'ANET',
+                              'BUY',
+                              100,
+                              50.00,
+                              0.0,
+                              'USD')
+    transactions = transactions_to_list([transaction])
+    with pytest.raises(ClickException):
+        filepath = create_csv_file(testfiles_dir,
+                                   "datewrongformat.csv,",
+                                   transactions,
+                                   True)
+        TransactionsReader.get_transactions(filepath)
+
+
+def test_transactions_qty_not_integer(testfiles_dir):
+    """Testing TransactionsReader with qty entered in wrong format"""
+    transaction = Transaction(date(2020, 2, 20),
+                              'RSU VEST',
+                              'ANET',
+                              'BUY',
+                              100.1,
+                              50.00,
+                              0.0,
+                              'USD')
+    transactions = transactions_to_list([transaction])
+    with pytest.raises(ClickException):
+        filepath = create_csv_file(testfiles_dir,
+                                   "qtynotinteger.csv,",
+                                   transactions,
+                                   True)
+        TransactionsReader.get_transactions(filepath)
+
+
+def test_transactions_price_not_float(testfiles_dir):
+    """Testing TransactionsReader with price entered in wrong format"""
+    transaction = Transaction(date(2020, 2, 20),
+                              'RSU VEST',
+                              'ANET',
+                              'BUY',
+                              100,
+                              "notafloat",
+                              0.0,
+                              'USD')
+    transactions = transactions_to_list([transaction])
+    with pytest.raises(ClickException):
+        filepath = create_csv_file(testfiles_dir,
+                                   "pricenotfloat.csv,",
+                                   transactions,
+                                   True)
+        TransactionsReader.get_transactions(filepath)
+
+
+def test_transactions_commission_not_float(testfiles_dir):
+    """Testing TransactionsReader with commission entered in wrong format"""
+    transaction = Transaction(date(2020, 2, 20),
+                              'RSU VEST',
+                              'ANET',
+                              'BUY',
+                              100,
+                              50.00,
+                              "notafloat",
+                              'USD')
+    transactions = transactions_to_list([transaction])
+    with pytest.raises(ClickException):
+        filepath = create_csv_file(testfiles_dir,
+                                   "commissionnotfloat.csv,",
+                                   transactions,
                                    True)
         TransactionsReader.get_transactions(filepath)


### PR DESCRIPTION
Test coverage is now 100%. Also, the codecov.yml file was created to enforce 100% line coverage for all future PRs.

Only changes to code that need to be made were in capgains_calc.py. There was 1 single line that wasn't being tested, but it was an impossible case since we expected transactions to be in order anyways. So, I rewrote the function and simplified it so that there isn't that giant for-loop anymore. Now, we just generate a group of lists with common currencies, and we know the order of the transactions are correct, so we can assume the first is the min date and the last is the max date.