### PR TITLE
Adding indication of total gains for each ticker right above the table

### DIFF
--- a/capgains/commands/capgains_calc.py
+++ b/capgains/commands/capgains_calc.py
@@ -64,6 +64,13 @@ def _filter_calculated_transaction(transaction, year):
     return True
 
 
+def _get_total_gains(calculated_dicts):
+    total = 0
+    for calculated_dict in calculated_dicts:
+        total += calculated_dict['capital_gain']
+    return "{0:,.2f}".format(total)
+
+
 def _get_map_of_currencies_to_exchange_rates(transactions):
     """First, split the list of transactions into sublists where each sublist
     will only contain transactions with the same currency"""
@@ -115,6 +122,8 @@ def capgains_calc(transactions, year, tickers=None):
         if not calculated_dicts:
             click.echo("No capital gains\n")
             continue
+        total_gains = _get_total_gains(calculated_dicts)
+        click.echo("[Total Gains = {}]\n".format(total_gains))
         headers = calculated_dicts[0].keys()
         rows = [t.values() for t in calculated_dicts]
         output = tabulate.tabulate(rows, headers=headers,

--- a/capgains/commands/capgains_calc.py
+++ b/capgains/commands/capgains_calc.py
@@ -68,7 +68,7 @@ def _get_total_gains(calculated_dicts):
     total = 0
     for calculated_dict in calculated_dicts:
         total += calculated_dict['capital_gain']
-    return "{0:,.2f}".format(total)
+    return total
 
 
 def _get_map_of_currencies_to_exchange_rates(transactions):
@@ -123,7 +123,7 @@ def capgains_calc(transactions, year, tickers=None):
             click.echo("No capital gains\n")
             continue
         total_gains = _get_total_gains(calculated_dicts)
-        click.echo("[Total Gains = {}]\n".format(total_gains))
+        click.echo("[Total Gains = {0:,.2f}]\n".format(total_gains))
         headers = calculated_dicts[0].keys()
         rows = [t.values() for t in calculated_dicts]
         output = tabulate.tabulate(rows, headers=headers,

--- a/tests/test_capgains.py
+++ b/tests/test_capgains.py
@@ -77,6 +77,8 @@ def test_calc_no_ticker_arg(testfiles_dir, transactions, exchange_rates_mock):
     assert result.exit_code == 0
     assert result.output == """\
 ANET-2018
+[Total Gains = 6,970.00]
+
 date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta       acb
 ----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  --------
 2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD               50   11,980.00        6,970.00    -5,010.00  5,010.00
@@ -100,6 +102,8 @@ def test_calc_ticker_arg(testfiles_dir, transactions, exchange_rates_mock):
     assert result.exit_code == 0
     assert result.output == """\
 ANET-2018
+[Total Gains = 6,970.00]
+
 date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta       acb
 ----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  --------
 2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD               50   11,980.00        6,970.00    -5,010.00  5,010.00

--- a/tests/test_capgains_calc.py
+++ b/tests/test_capgains_calc.py
@@ -11,6 +11,8 @@ def test_no_ticker(transactions, capfd, exchange_rates_mock):
     out, _ = capfd.readouterr()
     assert out == """\
 ANET-2018
+[Total Gains = 6,970.00]
+
 date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta       acb
 ----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  --------
 2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD               50   11,980.00        6,970.00    -5,010.00  5,010.00
@@ -27,6 +29,8 @@ def test_tickers(transactions, capfd, exchange_rates_mock):
     out, _ = capfd.readouterr()
     assert out == """\
 ANET-2018
+[Total Gains = 6,970.00]
+
 date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta       acb
 ----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  --------
 2018-02-20  RSU VEST            ANET      SELL         50   120.00         10.00         USD               50   11,980.00        6,970.00    -5,010.00  5,010.00
@@ -95,6 +99,8 @@ def test_superficial_loss_not_displayed(capfd, exchange_rates_mock):
     out, _ = capfd.readouterr()
     assert out == """\
 ANET-2018
+[Total Gains = 1,779.80]
+
 date        transaction_type    ticker    action      qty     price    commission    currency    share_balance    proceeds    capital_gain    acb_delta    acb
 ----------  ------------------  --------  --------  -----  --------  ------------  ----------  ---------------  ----------  --------------  -----------  -----
 2018-12-01  RSU VEST            ANET      SELL          1  1,000.00         10.00         USD                0    1,980.00        1,779.80      -200.20   0.00
@@ -138,6 +144,8 @@ def test_calc_mixed_currencies(capfd, requests_mock):
     out, _ = capfd.readouterr()
     assert out == """\
 ANET-2018
+[Total Gains = -5,000.00]
+
 date        transaction_type    ticker    action      qty    price    commission    currency    share_balance    proceeds    capital_gain    acb_delta    acb
 ----------  ------------------  --------  --------  -----  -------  ------------  ----------  ---------------  ----------  --------------  -----------  -----
 2018-02-20  RSU VEST            ANET      SELL        100    50.00          0.00         CAD                0    5,000.00       -5,000.00   -10,000.00   0.00


### PR DESCRIPTION
### Fixes #8 

Put the total gains right above the table, so users can quickly see what the gains are for that ticker/year combination without needing to manually sum up the values or scroll around looking for the gains.