### PR TITLE
Add support for BoC noon rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Canadian Capital Gains CLI Tool
 
 Calculating your capital gains and tracking your adjusted cost base (ACB) manually, or using an Excel document, often proves to be a laborious process. This CLI tool calculates your capital gains and ACB for you, and just requires a CSV file with basic information about your transactions. The idea with this tool is that you are able to more or less cut-and-copy the output that it genarates and copy it into whatever tax filing software you end up using. Please note that this tool is geared towards Canadians.
 
-Noteable features:
+## Noteable features:
 - Supports transactions with multiple different stock tickers in the same CSV file, and outputs them in separate tables.
 - Currently supports transactions done in both USD and CAD. For USD transactions, the daily exchange rate will be automatically fetched from the Bank of Canada.
 - Will automatically apply [superficial capital loss](https://www.canada.ca/en/revenue-agency/services/tax/individuals/topics/about-your-tax-return/tax-return/completing-a-tax-return/personal-income/line-127-capital-gains/capital-losses-deductions/what-a-superficial-loss.html) rules when calculating your capital gains and ACB. This tool only supports full superficial capital losses, and does not support partial superficial losses. In sales with a superficial capital loss, the capital loss will be carried forward as perscribed by the CRA. A sale with a capital loss will be treated as superficial if it satisifies the following:
     - Shares with the same ticker were bought in the 61 day window (30 days before or 30 days after the sale)
     - There is a non-zero balance of shares sharing the same ticker at the end of the 61 day window (30 days after the sale)
-- Outputs the running adjusted cost base (ACB) for every transaction
+- Outputs the running adjusted cost base (ACB) for every transaction with a non-superficial capital gain/loss
 
 # Installation
 ```bash
@@ -31,7 +31,8 @@ Here is a sample CSV file:
 2017-5-20,RSU VEST,GOOG,SELL,50,45.00,0.00,CAD
 ```
 
-**NOTE: Currently we only support calculating ACB and capital gains from January 3, 2017 and onwards. This is because the Bank of Canada exchange rate API only has data for that date and onwards. We are working on fixing this so that any date is supported.**
+**NOTE: This tool only supports calculating ACB and capital gains with transactions
+dating from May 1, 2007 and onwards.**
 
 # Usage
 To show the CSV file in a nice tabular format you can run:

--- a/capgains/exchange_rate.py
+++ b/capgains/exchange_rate.py
@@ -4,34 +4,59 @@ from click import ClickException
 
 
 class ExchangeRate:
-    min_date = date(2017, 1, 3)
+    indicative_rate_min_date = date(2017, 1, 3)
+    noon_rate_min_date = date(2007, 5, 1)
     valet_obs_url = 'https://www.bankofcanada.ca/valet/observations'
     observations = "observations"
     currency_to = 'CAD'
     date = 'd'
     value = 'v'
     supported_currencies = ['CAD', 'USD']
+    noon_rate_forex_str = {'USD': 'IEXE0101'}
 
-    def _init_cad_to_cad(self, start_date, end_date):
-        """The API doesn't support CAD -> CAD, so just set the rates to 1
-        for all days"""
-        num_days = (end_date - start_date).days + 1
-        for date in \
-                (start_date + timedelta(days=n) for n in range(num_days)):
-            self._rates[date] = 1
+    def __init__(self, currency_from, start_date, end_date):
+        self._currency_from = currency_from
+        self._start_date = start_date
+        self._end_date = end_date
+        self._rates = dict()
 
-    def _init_other_to_cad(self, currency_from, start_date, end_date):
+        if currency_from not in self.supported_currencies:
+            raise ClickException(
+                "Currency ({}) is not currently supported. The supported "
+                "currencies are {}" .format(currency_from,
+                                            self.supported_currencies))
+
+        if end_date < start_date:
+            raise ClickException(
+                "End date must be after start date")
+        if start_date < self.noon_rate_min_date:
+            raise ClickException(
+                "We do not support having transactions before {}"
+                .format(self.noon_rate_min_date.isoformat()))
+        if end_date > datetime.today().date():
+            raise ClickException(
+                "We do not support having transactions past today's date")
+
+        if currency_from == self.currency_to:
+            # Nothing to do if currencies are the same
+            return
+
+        noon_rates = self._fetch_noon_rates(start_date, end_date)
+        indicative_rates = self._fetch_indicative_rates(start_date, end_date)
+        self._rates.update(noon_rates)
+        self._rates.update(indicative_rates)
+
+    def _fetch_rates(self, start_date, end_date, forex_str):
+        """Fetch exchange rates from the supplied URL"""
+        rates = {}
         # Always move the start date back 7 days in case the start
         # date, end date, and all days in between are all weekends/holidays
         # where no exchange rate can be found
         start_date -= timedelta(days=7)
-
-        # Query for all the exchange rates in the range specified, and
-        # populates a dictionary that maps dates to exchange rates.
         params = {"start_date": start_date.isoformat(),
                   "end_date": end_date.isoformat()}
-        forex_str = "FX{}{}".format(self._currency_from, self.currency_to)
         url = "{}/{}/json".format(self.valet_obs_url, forex_str)
+        response = None
         try:
             response = requests.get(url=url, params=params)
         except requests.ConnectionError as e:
@@ -50,59 +75,65 @@ class ExchangeRate:
             raise ClickException(
                 "Catastrophic error with URL {} : {}".format(url, e))
         try:
-            rates = response.json()[self.observations]
+            rates_json = response.json()[self.observations]
         except KeyError:
             raise ClickException(
                 "No observations were found using currency {}"
                 .format(self._currency_from))
-        for day_rate in rates:
+        for day_rate in rates_json:
             date_str = day_rate[self.date]
             date = datetime.strptime(date_str, '%Y-%m-%d').date()
             rate = float(day_rate[forex_str][self.value])
-            self._rates[date] = rate
+            rates[date] = rate
+        return rates
 
-    def __init__(self, currency_from, start_date, end_date):
-        self._currency_from = currency_from
-        self._start_date = start_date
-        self._end_date = end_date
-        self._rates = dict()
+    def _fetch_noon_rates(self, start_date, end_date):
+        """Get the historical noon rates from the Bank of Canada"""
+        if start_date >= self.indicative_rate_min_date:
+            # No available noon dates for this date range
+            return {}
+        if end_date >= self.indicative_rate_min_date:
+            # Our date range overlaps with the noon rate and indicative rate
+            # boundary
+            end_date = self.indicative_rate_min_date - timedelta(days=1)
+        forex_str = self.noon_rate_forex_str[self._currency_from]
+        return self._fetch_rates(start_date, end_date, forex_str)
 
-        if currency_from not in self.supported_currencies:
-            raise ClickException(
-                "Currency ({}) is not currently supported. The supported currencies are {}"  # noqa: E501
-                .format(currency_from, self.supported_currencies))
-
-        if end_date < start_date:
-            raise ClickException(
-                "End date must be after start date")
-        if start_date < self.min_date:
-            raise ClickException(
-                "Start date is before minimum date {}"
-                .format(self.min_date.isoformat()))
-
-        if currency_from == 'CAD':
-            self._init_cad_to_cad(start_date, end_date)
-        else:
-            self._init_other_to_cad(currency_from, start_date,
-                                    end_date)
+    def _fetch_indicative_rates(self, start_date, end_date):
+        """Get the indicative rates from the Bank of Canada"""
+        if end_date < self.indicative_rate_min_date:
+            # No available indicative rates for this date range
+            return {}
+        if start_date < self.indicative_rate_min_date:
+            # Our date range overlaps with the noon rate and indicative rate
+            # boundary
+            start_date = self.indicative_rate_min_date
+        forex_str = "FX{}{}".format(self._currency_from, self.currency_to)
+        return self._fetch_rates(start_date, end_date, forex_str)
 
     def _get_closest_rate_for_day(self, date):
-        """Gets the exchange rate for the closest
-        preceeding date with a rate"""
-        if date <= self.min_date:
-            return None
+        """Gets the exchange rate for the closest preceeding date with a
+        rate
+        """
         if date in self._rates:
             return self._rates[date]
         dates_preceeding = [d for d in self._rates if d < date]
-        closest_date = min(dates_preceeding, key=lambda d: abs(d-date))
-        return self._rates[closest_date]
+        if dates_preceeding:
+            closest_date = min(dates_preceeding, key=lambda d: (date - d))
+            return self._rates[closest_date]
+        return None
 
     def get_rate(self, date):
         """Gets the exchange rate either:
         (1) for the day if an exchange rate exists for that day
         (2) for the closest preceeding day if an exchange rate does
             not exist for that day"""
-        rate = self._get_closest_rate_for_day(date)
+        if self._currency_from == self.currency_to:
+            # Converting CAD to CAD
+            rate = 1.00
+        else:
+            # Converting Non-CAD to CAD
+            rate = self._get_closest_rate_for_day(date)
         if not rate:
             raise ClickException(
                 "Unable to find exchange rate on {}".format(date))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,10 @@ version = "1.0.0"
 description = "A CLI tool to calculate your capital gains"
 license = "MIT"
 readme = "README.md"
+maintainers = [
+    "Eddy Maric",
+    "Emil Maric"
+]
 authors = [
     "Eddy Maric",
     "Emil Maric"


### PR DESCRIPTION
Fixes #10 

Add support for fetching Bank of Canada noon rates. This allows us to
set the minimum date for transactions to be May 1, 2007 instead of Jan.
3, 2017.

For transactions with dates that fall before Jan. 3, 2017, they will use
the noon rate from Bank of Canada. For transactions with dates that fall
after or on Jan. 3, 2017, they will use the indicative rate from Bank of
Canada.