### PR TITLE
Fix pypi deployment step failing on py35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - '3.5'
   - '3.6'
   - '3.7'
 before_install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 click = "^7.1.2"
 tabulate = "^0.8.7"
 requests = "^2.23.0"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = true
 skipsdist=true
-envlist = py{35,36,37},flake8
+envlist = py{36,37},flake8
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
Travis can't deploy to pypi if the python version is 3.5 because pip
stopped supporting python version 3.5. It's probably easier just to drop
python3.5 support altogether for this app to get it to work with travis.