### PR TITLE
Drop support for Python3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 click = "^7.1.2"
 tabulate = "^0.8.7"
 requests = "^2.23.0"


### PR DESCRIPTION
Since pip doesn't support python3.5 on travis, we should just drop
support for it on our app. That will make deploying to pypi simpler
rather than trying to support python3.5.