### PR TITLE
Support partial share purchases/sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Calculating your capital gains and tracking your adjusted cost base (ACB) manual
     - Shares with the same ticker were bought in the 61 day window (30 days before or 30 days after the sale)
     - There is a non-zero balance of shares sharing the same ticker at the end of the 61 day window (30 days after the sale)
 - Outputs the running adjusted cost base (ACB) for every transaction with a non-superficial capital gain/loss
+- Supports fractional quantities of shares
 
 # Installation
 ```bash

--- a/capgains/commands/capgains_calc.py
+++ b/capgains/commands/capgains_calc.py
@@ -10,22 +10,11 @@ colalign = (
     "left",   # date
     "left",   # description
     "left",   # ticker
-    "left",   # qty
+    "right",  # qty
     "right",  # proceeds
     "right",  # acb
     "right",  # commission
     "right",  # capital gain
-)
-
-floatfmt = (
-    None,    # date
-    None,    # description
-    None,    # ticker
-    None,    # qty
-    ",.2f",  # proceeds
-    ",.2f",  # acb
-    ",.2f",  # commission
-    ",.2f",  # capital gain
 )
 
 
@@ -84,12 +73,12 @@ def capgains_calc(transactions, year, tickers=None):
             t.date,
             t.description,
             t.ticker,
-            t.qty,
-            t.proceeds,
-            t.acb,
-            t.expenses,
-            t.capital_gain
+            "{0:f}".format(t.qty.normalize()),
+            "{:,.2f}".format(t.proceeds),
+            "{:,.2f}".format(t.acb),
+            "{:,.2f}".format(t.expenses),
+            "{:,.2f}".format(t.capital_gain)
         ] for t in transactions_to_report]
         output = tabulate.tabulate(rows, headers=headers, tablefmt="psql",
-                                   colalign=colalign, floatfmt=floatfmt)
+                                   colalign=colalign, disable_numparse=True)
         click.echo("{}\n".format(output))

--- a/capgains/commands/capgains_show.py
+++ b/capgains/commands/capgains_show.py
@@ -14,17 +14,6 @@ colalign = (
     "right",  # currency
 )
 
-floatfmt = (
-    None,    # date
-    None,    # description
-    None,    # ticker
-    None,    # action
-    None,    # qty
-    ",.2f",  # price
-    ",.2f",  # commission
-    None,    # currency
-)
-
 
 def capgains_show(transactions, tickers=None):
     """Take a list of transactions and print them in tabular format."""
@@ -39,11 +28,11 @@ def capgains_show(transactions, tickers=None):
         t.description,
         t.ticker,
         t.action,
-        t.qty,
-        t.price,
-        t.commission,
+        "{0:f}".format(t.qty.normalize()),
+        "{:,.2f}".format(t.price),
+        "{:,.2f}".format(t.commission),
         t.currency
     ] for t in filtered_transactions]
     output = tabulate.tabulate(rows, headers=headers, colalign=colalign,
-                               tablefmt="psql", floatfmt=floatfmt)
+                               tablefmt="psql", disable_numparse=True)
     click.echo(output)

--- a/capgains/exchange_rate.py
+++ b/capgains/exchange_rate.py
@@ -1,5 +1,6 @@
 import requests
 from datetime import date, timedelta, datetime
+from decimal import Decimal
 from click import ClickException
 
 
@@ -83,7 +84,7 @@ class ExchangeRate:
         for day_rate in rates_json:
             date_str = day_rate[self.date]
             date = datetime.strptime(date_str, '%Y-%m-%d').date()
-            rate = float(day_rate[forex_str][self.value])
+            rate = Decimal(day_rate[forex_str][self.value])
             rates[date] = rate
         return rates
 
@@ -130,7 +131,7 @@ class ExchangeRate:
             not exist for that day"""
         if self._currency_from == self.currency_to:
             # Converting CAD to CAD
-            rate = 1.00
+            rate = Decimal(1.00)
         else:
             # Converting Non-CAD to CAD
             rate = self._get_closest_rate_for_day(date)

--- a/capgains/ticker_gains.py
+++ b/capgains/ticker_gains.py
@@ -1,5 +1,6 @@
 from click import ClickException
 from datetime import timedelta
+from decimal import Decimal
 
 
 class TickerGains:
@@ -62,7 +63,7 @@ class TickerGains:
         else:
             self._share_balance += transaction.qty
             acb = proceeds + transaction.expenses
-            capital_gain = 0.0
+            capital_gain = Decimal(0.0)
             self._total_acb += acb
         if self._share_balance < 0:
             raise ClickException("Transaction caused negative share balance")

--- a/capgains/transaction.py
+++ b/capgains/transaction.py
@@ -1,3 +1,6 @@
+from decimal import Decimal
+
+
 class Transaction:
     """Represents a transaction entry from the CSV-file"""
 
@@ -7,15 +10,15 @@ class Transaction:
         self._description = description
         self._ticker = ticker
         self._action = action
-        self._qty = qty
-        self._price = price
-        self._commission = commission
+        self._qty = Decimal(qty)
+        self._price = Decimal(price)
+        self._commission = Decimal(commission)
         self._currency = currency
         self._exchange_rate = None
-        self._share_balance = 0
-        self._proceeds = 0.0
-        self._capital_gain = 0.0
-        self._acb = 0.0
+        self._share_balance = Decimal(0.0)
+        self._proceeds = Decimal(0.0)
+        self._capital_gain = Decimal(0.0)
+        self._acb = Decimal(0.0)
         self._superficial_loss = False
 
     @property
@@ -56,7 +59,7 @@ class Transaction:
 
     @exchange_rate.setter
     def exchange_rate(self, exchange_rate):
-        self._exchange_rate = exchange_rate
+        self._exchange_rate = Decimal(exchange_rate)
 
     @property
     def share_balance(self):
@@ -66,7 +69,7 @@ class Transaction:
     def share_balance(self, share_balance):
         if (share_balance < 0):
             raise ValueError("Share balance cannot be negative")
-        self._share_balance = share_balance
+        self._share_balance = Decimal(share_balance)
 
     @property
     def proceeds(self):
@@ -74,7 +77,7 @@ class Transaction:
 
     @proceeds.setter
     def proceeds(self, proceeds):
-        self._proceeds = proceeds
+        self._proceeds = Decimal(proceeds)
 
     @property
     def capital_gain(self):
@@ -82,7 +85,7 @@ class Transaction:
 
     @capital_gain.setter
     def capital_gain(self, capital_gain):
-        self._capital_gain = capital_gain
+        self._capital_gain = Decimal(capital_gain)
 
     @property
     def acb(self):
@@ -90,7 +93,7 @@ class Transaction:
 
     @acb.setter
     def acb(self, acb):
-        self._acb = acb
+        self._acb = Decimal(acb)
 
     @property
     def superficial_loss(self):
@@ -98,7 +101,7 @@ class Transaction:
 
     @superficial_loss.setter
     def superficial_loss(self, superficial_loss):
-        self._superficial_loss = superficial_loss
+        self._superficial_loss = Decimal(superficial_loss)
 
     @property
     def expenses(self):
@@ -106,4 +109,4 @@ class Transaction:
 
     def set_superficial_loss(self):
         self.superficial_loss = True
-        self.capital_gain = 0.0
+        self.capital_gain = Decimal(0.0)

--- a/capgains/transactions_reader.py
+++ b/capgains/transactions_reader.py
@@ -1,6 +1,7 @@
 import csv
 from click import ClickException
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 
 from .transaction import Transaction
 from .transactions import Transactions
@@ -53,26 +54,26 @@ class TransactionsReader:
                     qty_idx = cls.columns.index("qty")
                     qty_str = entry[qty_idx]
                     try:
-                        entry[qty_idx] = int(qty_str)
-                    except ValueError:
+                        entry[qty_idx] = Decimal(qty_str)
+                    except InvalidOperation:
                         raise ClickException(
-                            "The quanitity entered {} is not an integer"
+                            "The quantity entered {} is not a valid number"
                             .format(qty_str))
                     price_idx = cls.columns.index("price")
                     price_str = entry[price_idx]
                     try:
-                        entry[price_idx] = float(price_str)
-                    except ValueError:
+                        entry[price_idx] = Decimal(price_str)
+                    except InvalidOperation:
                         raise ClickException(
-                            "The price entered {} is not a float value"
+                            "The price entered {} is not a valid number"
                             .format(price_str))
                     commission_idx = cls.columns.index("commission")
                     commission_str = entry[commission_idx]
                     try:
-                        entry[commission_idx] = float(commission_str)
-                    except ValueError:
+                        entry[commission_idx] = Decimal(commission_str)
+                    except InvalidOperation:
                         raise ClickException(
-                            "The commission entered {} is not a float value"
+                            "The commission entered {} is not a valid number"
                             .format(commission_str))
                     transaction = Transaction(*entry)
                     if last_date:

--- a/tests/test_capgains.py
+++ b/tests/test_capgains.py
@@ -78,9 +78,9 @@ def test_calc_no_ticker_arg(testfiles_dir, transactions, exchange_rates_mock):
 ANET-2018
 [Total Gains = 6,970.00]
 +------------+---------------+----------+-------+------------+----------+-----------+---------------------+
-| date       | description   | ticker   | qty   |   proceeds |      ACB |   outlays |   capital gain/loss |
+| date       | description   | ticker   |   qty |   proceeds |      ACB |   outlays |   capital gain/loss |
 |------------+---------------+----------+-------+------------+----------+-----------+---------------------|
-| 2018-02-20 | RSU VEST      | ANET     | 50    |  12,000.00 | 5,010.00 |     20.00 |            6,970.00 |
+| 2018-02-20 | RSU VEST      | ANET     |    50 |  12,000.00 | 5,010.00 |     20.00 |            6,970.00 |
 +------------+---------------+----------+-------+------------+----------+-----------+---------------------+
 
 GOOGL-2018
@@ -104,9 +104,9 @@ def test_calc_ticker_arg(testfiles_dir, transactions, exchange_rates_mock):
 ANET-2018
 [Total Gains = 6,970.00]
 +------------+---------------+----------+-------+------------+----------+-----------+---------------------+
-| date       | description   | ticker   | qty   |   proceeds |      ACB |   outlays |   capital gain/loss |
+| date       | description   | ticker   |   qty |   proceeds |      ACB |   outlays |   capital gain/loss |
 |------------+---------------+----------+-------+------------+----------+-----------+---------------------|
-| 2018-02-20 | RSU VEST      | ANET     | 50    |  12,000.00 | 5,010.00 |     20.00 |            6,970.00 |
+| 2018-02-20 | RSU VEST      | ANET     |    50 |  12,000.00 | 5,010.00 |     20.00 |            6,970.00 |
 +------------+---------------+----------+-------+------------+----------+-----------+---------------------+
 
 """  # noqa: E501

--- a/tests/test_capgains_calc.py
+++ b/tests/test_capgains_calc.py
@@ -14,9 +14,9 @@ def test_no_ticker(transactions, capfd, exchange_rates_mock):
 ANET-2018
 [Total Gains = 6,970.00]
 +------------+---------------+----------+-------+------------+----------+-----------+---------------------+
-| date       | description   | ticker   | qty   |   proceeds |      ACB |   outlays |   capital gain/loss |
+| date       | description   | ticker   |   qty |   proceeds |      ACB |   outlays |   capital gain/loss |
 |------------+---------------+----------+-------+------------+----------+-----------+---------------------|
-| 2018-02-20 | RSU VEST      | ANET     | 50    |  12,000.00 | 5,010.00 |     20.00 |            6,970.00 |
+| 2018-02-20 | RSU VEST      | ANET     |    50 |  12,000.00 | 5,010.00 |     20.00 |            6,970.00 |
 +------------+---------------+----------+-------+------------+----------+-----------+---------------------+
 
 GOOGL-2018
@@ -33,9 +33,9 @@ def test_tickers(transactions, capfd, exchange_rates_mock):
 ANET-2018
 [Total Gains = 6,970.00]
 +------------+---------------+----------+-------+------------+----------+-----------+---------------------+
-| date       | description   | ticker   | qty   |   proceeds |      ACB |   outlays |   capital gain/loss |
+| date       | description   | ticker   |   qty |   proceeds |      ACB |   outlays |   capital gain/loss |
 |------------+---------------+----------+-------+------------+----------+-----------+---------------------|
-| 2018-02-20 | RSU VEST      | ANET     | 50    |  12,000.00 | 5,010.00 |     20.00 |            6,970.00 |
+| 2018-02-20 | RSU VEST      | ANET     |    50 |  12,000.00 | 5,010.00 |     20.00 |            6,970.00 |
 +------------+---------------+----------+-------+------------+----------+-----------+---------------------+
 
 """  # noqa: E501
@@ -105,16 +105,16 @@ def test_superficial_loss_not_displayed(capfd, exchange_rates_mock):
 ANET-2018
 [Total Gains = -8,160.00]
 +------------+---------------+----------+-------+------------+-----------+-----------+---------------------+
-| date       | description   | ticker   | qty   |   proceeds |       ACB |   outlays |   capital gain/loss |
+| date       | description   | ticker   |   qty |   proceeds |       ACB |   outlays |   capital gain/loss |
 |------------+---------------+----------+-------+------------+-----------+-----------+---------------------|
-| 2018-12-01 | RSU VEST      | ANET     | 1     |   2,000.00 | 10,140.00 |     20.00 |           -8,160.00 |
+| 2018-12-01 | RSU VEST      | ANET     |     1 |   2,000.00 | 10,140.00 |     20.00 |           -8,160.00 |
 +------------+---------------+----------+-------+------------+-----------+-----------+---------------------+
 
 """  # noqa: E501
 
 
 def test_calc_mixed_currencies(capfd, requests_mock):
-    """testing capgains_calc with mixed currencies"""
+    """Testing capgains_calc with mixed currencies"""
     usd_transaction = Transaction(
             date(2017, 2, 15),
             'ESPP PURCHASE',
@@ -151,9 +151,48 @@ def test_calc_mixed_currencies(capfd, requests_mock):
 ANET-2018
 [Total Gains = -5,000.00]
 +------------+---------------+----------+-------+------------+-----------+-----------+---------------------+
-| date       | description   | ticker   | qty   |   proceeds |       ACB |   outlays |   capital gain/loss |
+| date       | description   | ticker   |   qty |   proceeds |       ACB |   outlays |   capital gain/loss |
 |------------+---------------+----------+-------+------------+-----------+-----------+---------------------|
-| 2018-02-20 | RSU VEST      | ANET     | 100   |   5,000.00 | 10,000.00 |      0.00 |           -5,000.00 |
+| 2018-02-20 | RSU VEST      | ANET     |   100 |   5,000.00 | 10,000.00 |      0.00 |           -5,000.00 |
 +------------+---------------+----------+-------+------------+-----------+-----------+---------------------+
+
+"""  # noqa: E501
+
+
+def test_partial_shares(capfd, requests_mock):
+    """Testing capgains_calc with partial shares"""
+    partial_buy = Transaction(
+        date(2017, 2, 15),
+        'ESPP PURCHASE',
+        'ANET',
+        'BUY',
+        0.5,
+        50.00,
+        0.00,
+        'CAD')
+    partial_sell = Transaction(
+        date(2018, 2, 20),
+        'RSU VEST',
+        'ANET',
+        'SELL',
+        0.5,
+        100.00,
+        0.00,
+        'CAD')
+    transactions = Transactions([
+        partial_buy,
+        partial_sell
+    ])
+
+    CapGainsCalc.capgains_calc(transactions, 2018)
+    out, _ = capfd.readouterr()
+    assert out == """\
+ANET-2018
+[Total Gains = 25.00]
++------------+---------------+----------+-------+------------+-------+-----------+---------------------+
+| date       | description   | ticker   |   qty |   proceeds |   ACB |   outlays |   capital gain/loss |
+|------------+---------------+----------+-------+------------+-------+-----------+---------------------|
+| 2018-02-20 | RSU VEST      | ANET     |   0.5 |      50.00 | 25.00 |      0.00 |               25.00 |
++------------+---------------+----------+-------+------------+-------+-----------+---------------------+
 
 """  # noqa: E501

--- a/tests/test_capgains_show.py
+++ b/tests/test_capgains_show.py
@@ -1,4 +1,7 @@
+from datetime import date
+
 from capgains.commands import capgains_show as CapGainsShow
+from capgains.transaction import Transaction
 from capgains.transactions import Transactions
 
 
@@ -82,5 +85,42 @@ def test_multiple_tickers(transactions, capfd):
 | 2018-02-20 | RSU VEST      | GOOGL    | BUY      |    30 |   20.00 |        10.00 |        USD |
 | 2018-02-20 | RSU VEST      | ANET     | SELL     |    50 |  120.00 |        10.00 |        USD |
 | 2019-02-15 | ESPP PURCHASE | ANET     | BUY      |    50 |  130.00 |        10.00 |        USD |
++------------+---------------+----------+----------+-------+---------+--------------+------------+
+"""  # noqa: E501
+
+
+def test_partial_shares(capfd, requests_mock):
+    """Testing capgains_show with partial shares"""
+    partial_buy = Transaction(
+        date(2017, 2, 15),
+        'ESPP PURCHASE',
+        'ANET',
+        'BUY',
+        0.5,
+        50.00,
+        0.00,
+        'CAD')
+    partial_sell = Transaction(
+        date(2018, 2, 20),
+        'RSU VEST',
+        'ANET',
+        'SELL',
+        0.5,
+        100.00,
+        0.00,
+        'CAD')
+    transactions = Transactions([
+        partial_buy,
+        partial_sell
+    ])
+
+    CapGainsShow.capgains_show(transactions, ['ANET'])
+    out, _ = capfd.readouterr()
+    assert out == """\
++------------+---------------+----------+----------+-------+---------+--------------+------------+
+| date       | description   | ticker   | action   |   qty |   price |   commission |   currency |
+|------------+---------------+----------+----------+-------+---------+--------------+------------|
+| 2017-02-15 | ESPP PURCHASE | ANET     | BUY      |   0.5 |   50.00 |         0.00 |        CAD |
+| 2018-02-20 | RSU VEST      | ANET     | SELL     |   0.5 |  100.00 |         0.00 |        CAD |
 +------------+---------------+----------+----------+-------+---------+--------------+------------+
 """  # noqa: E501

--- a/tests/test_exchange_rate.py
+++ b/tests/test_exchange_rate.py
@@ -1,9 +1,11 @@
-from datetime import date, timedelta, datetime
 import pytest
-from click import ClickException
 import re
 import requests_mock as rm
 import requests
+
+from datetime import date, timedelta, datetime
+from decimal import Decimal
+from click import ClickException
 
 from capgains.exchange_rate import ExchangeRate
 
@@ -90,7 +92,7 @@ def test_exchange_rate_ok_date(USD_exchange_rates_mock):
     thursday = date(2020, 5, 21)
     friday = date(2020, 5, 22)
     er = ExchangeRate('USD', thursday, friday)
-    assert er.get_rate(friday) == 1.3
+    assert er.get_rate(friday) == Decimal('1.3')
 
 
 def test_exchange_rate_weekend_date(USD_exchange_rates_mock):
@@ -106,15 +108,15 @@ def test_exchange_rate_noon_only(USD_exchange_rates_mock):
     noon_rate_date = date(2016, 5, 21)
     er = ExchangeRate('USD', noon_rate_date, noon_rate_date)
     expected_rate = er.get_rate(noon_rate_date)
-    assert expected_rate == 1.1
+    assert expected_rate == Decimal('1.1')
 
 
 def test_exchange_rate_noon_and_indicative(USD_exchange_rates_mock):
     noon_rate_date = date(2016, 5, 21)
     indicative_rate_date = date(2020, 5, 22)
     er = ExchangeRate('USD', noon_rate_date, indicative_rate_date)
-    assert er.get_rate(noon_rate_date) == 1.1
-    assert er.get_rate(indicative_rate_date) == 1.3
+    assert er.get_rate(noon_rate_date) == Decimal('1.1')
+    assert er.get_rate(indicative_rate_date) == Decimal('1.3')
 
 
 def test_cad_to_cad_rate_is_1():

--- a/tests/test_transactions_reader.py
+++ b/tests/test_transactions_reader.py
@@ -117,7 +117,7 @@ def test_transactions_date_wrong_format(testfiles_dir):
     assert excinfo.value.message == "The date (January 1st 2020) was not entered in the correct format (YYYY-MM-DD)"  # noqa: E501
 
 
-def test_transactions_qty_not_integer(testfiles_dir):
+def test_transactions_qty_not_number(testfiles_dir):
     """Testing TransactionsReader with qty entered in wrong format"""
     transaction = Transaction(date(2020, 2, 20),
                               'RSU VEST',
@@ -140,7 +140,7 @@ def test_transactions_qty_not_integer(testfiles_dir):
     assert excinfo.value.message == "The quantity entered BLAH is not a valid number"  # noqa: E501
 
 
-def test_transactions_price_not_float(testfiles_dir):
+def test_transactions_price_not_number(testfiles_dir):
     """Testing TransactionsReader with price entered in wrong format"""
     transaction = Transaction(date(2020, 2, 20),
                               'RSU VEST',
@@ -163,7 +163,7 @@ def test_transactions_price_not_float(testfiles_dir):
     assert excinfo.value.message == "The price entered BLAH is not a valid number"  # noqa: E501
 
 
-def test_transactions_commission_not_float(testfiles_dir):
+def test_transactions_commission_not_number(testfiles_dir):
     """Testing TransactionsReader with commission entered in wrong format"""
     transaction = Transaction(date(2020, 2, 20),
                               'RSU VEST',

--- a/tests/test_transactions_reader.py
+++ b/tests/test_transactions_reader.py
@@ -127,6 +127,9 @@ def test_transactions_qty_not_integer(testfiles_dir):
                               50.00,
                               0.0,
                               'USD')
+    # Overwrite the qty after creating the object because otherwise the object
+    # initialization will throw an error
+    transaction._qty = 'BLAH'
     transactions = transactions_to_list([transaction])
     filepath = create_csv_file(testfiles_dir,
                                "qtynotinteger.csv,",
@@ -134,7 +137,7 @@ def test_transactions_qty_not_integer(testfiles_dir):
                                True)
     with pytest.raises(ClickException) as excinfo:
         TransactionsReader.get_transactions(filepath)
-    assert excinfo.value.message == "The quanitity entered 100.1 is not an integer"  # noqa: E501
+    assert excinfo.value.message == "The quantity entered BLAH is not a valid number"  # noqa: E501
 
 
 def test_transactions_price_not_float(testfiles_dir):
@@ -144,9 +147,12 @@ def test_transactions_price_not_float(testfiles_dir):
                               'ANET',
                               'BUY',
                               100,
-                              "notafloat",
+                              100,
                               0.0,
                               'USD')
+    # Overwrite the price after creating the object because otherwise the
+    # object initialization will throw an error
+    transaction._price = 'BLAH'
     transactions = transactions_to_list([transaction])
     filepath = create_csv_file(testfiles_dir,
                                "pricenotfloat.csv,",
@@ -154,7 +160,7 @@ def test_transactions_price_not_float(testfiles_dir):
                                True)
     with pytest.raises(ClickException) as excinfo:
         TransactionsReader.get_transactions(filepath)
-    assert excinfo.value.message == "The price entered notafloat is not a float value"  # noqa: E501
+    assert excinfo.value.message == "The price entered BLAH is not a valid number"  # noqa: E501
 
 
 def test_transactions_commission_not_float(testfiles_dir):
@@ -165,8 +171,11 @@ def test_transactions_commission_not_float(testfiles_dir):
                               'BUY',
                               100,
                               50.00,
-                              "notafloat",
+                              0.0,
                               'USD')
+    # Overwrite the commission after creating the object because otherwise the
+    # object initialization will throw an error
+    transaction._commission = 'BLAH'
     transactions = transactions_to_list([transaction])
     filepath = create_csv_file(testfiles_dir,
                                "commissionnotfloat.csv,",
@@ -174,4 +183,4 @@ def test_transactions_commission_not_float(testfiles_dir):
                                True)
     with pytest.raises(ClickException) as excinfo:
         TransactionsReader.get_transactions(filepath)
-    assert excinfo.value.message == "The commission entered notafloat is not a float value"  # noqa: E501
+    assert excinfo.value.message == "The commission entered BLAH is not a valid number"  # noqa: E501


### PR DESCRIPTION
Fixes #24 

Something that is possible through some brokerages is the purchase and
sale of partial shares. This means that the `qty` value isn't
necessarily an integer, but could be represented as a floating point.
This can also occur for things like bitcoin or currency, where you will
most likely hold a certain fraction of a coin/currency. The primary
change was to support having decimal/float values for the quantity.

Additionally, I noticed that we were doing a lot of floating point math.
While this is good for approximations, it is better to be precise. I
discovered that there is a `decimal` python library that allows you to
work with precise decimal objects that don't have weird rounding rules
like floats. Anywhere where we did floating point math or where we
returned floats, I converted to use a Decimal instead.

I had one small issue with getting the correct amount of decimal values
to show up for the values under the `qty` column. I wanted to show all
the digits after the decimal, without truncating any digits but trimming
trailing zeroes. In order to do this, I had to get rid of the `floatfmt` tuple
for the tabulate tables and instead, do my own float pre-formatting for every
float value.