### PR TITLE
Reduces number of exchange requests for large transaction lists.

### DIFF
--- a/capgains/commands/capgains_calc.py
+++ b/capgains/commands/capgains_calc.py
@@ -28,7 +28,10 @@ def _get_total_gains(transactions):
 def _get_map_of_currencies_to_exchange_rates(transactions):
     """First, split the list of transactions into sublists where each sublist
     will only contain transactions with the same currency"""
-    currency_groups = [list(g) for _, g in groupby(transactions,
+
+    contiguous_currencies = sorted(transactions.transactions,
+                                   key=lambda t: t.currency)
+    currency_groups = [list(g) for _, g in groupby(contiguous_currencies,
                                                    lambda t: t.currency)]
     currencies_to_exchange_rates = dict()
     # Create a separate ExchangeRate object for each currency


### PR DESCRIPTION
Hi! I'm using your project because I have a CSV file with 3000 transactions that I need to process.

If you're open to it, I'll probably send you some other PRs, or at least report a few issues that I've had to overcome to make use of all your hard work!

This one is because how itertools.groupby works. It only creates groups out of contiguous items.

So, for example, if every transaction (sorted by date) alternated currency, would get a group for every single transaction.
Downstream, this will translate into many FX calls.

This change makes a copy of transactions that is sorted by currency and uses that list to get the groups. On my data, this took me from 1300 groups -> 2 groups (as I would expect).
