### PR TITLE
Fix v2.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: python
 python:
   - '3.8'
@@ -5,8 +6,6 @@ python:
 before_install:
   - pip install poetry
   - pip install codecov
-  - pip uninstall -y urllib3
-  - pip install urllib3==1.26.6
 install:
   - poetry install -v
   - pip install tox-travis

--- a/poetry.lock
+++ b/poetry.lock
@@ -531,19 +531,20 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psu
 
 [[package]]
 name = "urllib3"
-version = "1.26.6"
+version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=3.8"
 files = [
-    {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
-    {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
+    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
 ]
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+h2 = ["h2 (>=4,<5)"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -579,4 +580,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c26b137159ae6386bd349238df6f7d6297dcfe1d064c786cbd9037d7513a24a9"
+content-hash = "3f271ce22e8e1418b6a9936fefb5426875db40695f55b89e746a2a88ef123ce6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ python = "^3.8"
 click = "^7.1.2"
 tabulate = "^0.8.7"
 requests = "^2.23.0"
-urllib3 = "1.26.6"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Use newer version of Ubuntu for Travis builds, which use OpenSSL1.1.1,
instead of older versions which are using OpenSSL1.0.2. urllib3, which
is a depedency for a bunch of other python tools, requires OpenSSL1.1.1+
in order to use the v2 version of it.